### PR TITLE
Pins the platform version

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -10,6 +10,8 @@
 
 
 [common]
+; Version 6.11.0 of the espressif32 platform was chosen for its stability and compatibility with the current project setup.
+; Review this version periodically (e.g., every 6 months) to ensure compatibility with newer versions or to address potential issues.
 platform = espressif32@6.11.0
 framework = arduino
 monitor_speed = 115200

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -10,7 +10,7 @@
 
 
 [common]
-; Version 6.11.0 of the espressif32 platform was chosen for its stability and compatibility with the current project setup.
+; Version 6.11.0 of the espressif32 platform was chosen for its stability and compatibility with the current project setup. Pinned on: 2023-10-01.
 ; Review this version periodically (e.g., every 6 months) to ensure compatibility with newer versions or to address potential issues.
 platform = espressif32@6.11.0
 framework = arduino

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -10,7 +10,7 @@
 
 
 [common]
-; Version 6.11.0 of the espressif32 platform was chosen for its stability and compatibility with the current project setup. Pinned on: 2023-10-01.
+; Version 6.11.0 of the espressif32 platform was chosen for its stability and compatibility with the current project setup. Pinned on: 2025-07-19.
 ; Review this version periodically (e.g., every 6 months) to ensure compatibility with newer versions or to address potential issues.
 platform = espressif32@6.11.0
 framework = arduino

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -10,7 +10,7 @@
 
 
 [common]
-platform = espressif32
+platform = espressif32@6.11.0
 framework = arduino
 monitor_speed = 115200
 build_flags = 


### PR DESCRIPTION
Fixes #12 

I think this is a good/sensible thing to do. My only concern is that we may drift from the PlatformIO releases.

I've seen quite a few projects where they haven't kept up to date and now they can't build their projects on the latest versions.