### PR TITLE
Poke screen

### DIFF
--- a/firmware/src/Screens/EmulatorScreen.cpp
+++ b/firmware/src/Screens/EmulatorScreen.cpp
@@ -9,6 +9,7 @@
 #include "AlphabetPicker.h"
 #include "GameFilePickerScreen.h"
 #include "NavigationStack.h"
+#include "PokeScreen.h"
 #include "SaveSnapshotScreen.h"
 #include "EmulatorScreen/Renderer.h"
 #include "EmulatorScreen/Machine.h"
@@ -170,6 +171,9 @@ void EmulatorScreen::pressKey(SpecKeys key)
       renderer->isShowingMenu = false;
       // show the save snapshot UI
       m_navigationStack->push(new SaveSnapshotScreen(m_tft, m_hdmiDisplay, m_audioOutput, machine->getMachine(), m_files));
+    } else if (key == SPECKEY_P) {
+      renderer->isShowingMenu = false;
+      m_navigationStack->push(new PokeScreen(m_tft, m_hdmiDisplay, m_audioOutput, machine->getMachine()));
     } else if (key == SPECKEY_SPACE || key == SPECKEY_ENTER) {
       renderer->isShowingMenu = false;
       machine->resume();

--- a/firmware/src/Screens/MessageScreen.cpp
+++ b/firmware/src/Screens/MessageScreen.cpp
@@ -1,0 +1,20 @@
+#include "MessageScreen.h"
+
+void MessageScreen::updateDisplay()
+{
+    m_tft.startWrite();
+    m_tft.fillRect(0, 0, m_tft.width(), m_tft.height(), TFT_BLACK);
+    m_tft.drawRect(0, 0, m_tft.width(), m_tft.height(), TFT_WHITE);
+
+    m_tft.loadFont(GillSans_25_vlw);
+    m_tft.drawCenterString(m_title.c_str(), 5);
+
+    m_tft.loadFont(GillSans_15_vlw);
+    int16_t y = 30;
+    for (int i=0; i<m_messages.size(); i++){
+        m_tft.drawString(m_messages[i].c_str(), 5, y);
+        y += 20;
+    }
+
+    m_tft.endWrite();
+}

--- a/firmware/src/Screens/MessageScreen.h
+++ b/firmware/src/Screens/MessageScreen.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "NavigationStack.h"
+#include "Screen.h"
+#include "../TFT/TFTDisplay.h"
+#include "fonts/GillSans_25_vlw.h"
+#include "fonts/GillSans_15_vlw.h"
+
+class IFiles;
+
+class MessageScreen : public Screen
+{
+private:
+  std::string m_title;
+  std::vector<std::string> m_messages;
+public:
+  MessageScreen(
+      std::string title,
+      std::vector<std::string> messages,
+      Display &tft,
+      HDMIDisplay *hdmiDisplay,
+      AudioOutput *audioOutput) : m_title{title}, m_messages{messages}, Screen(tft, hdmiDisplay, audioOutput, nullptr)
+  {
+  }
+
+  void didAppear()
+  {
+    updateDisplay();
+  }
+
+  void pressKey(SpecKeys key)
+  {
+    m_navigationStack->pop();
+  }
+
+  void updateDisplay();
+};

--- a/firmware/src/Screens/PokeScreen.cpp
+++ b/firmware/src/Screens/PokeScreen.cpp
@@ -1,0 +1,242 @@
+#include "MessageScreen.h"
+#include "NavigationStack.h"
+#include "PokeScreen.h"
+#include "Screen.h"
+#include "../TFT/TFTDisplay.h"
+#include "fonts/GillSans_25_vlw.h"
+#include "fonts/GillSans_15_vlw.h"
+#include "../Emulator/spectrum.h"
+#include "../Emulator/snaps.h"
+
+#include <sstream>
+
+#define CURSOR_COLOR  TFT_CYAN
+
+void PokeScreen::pressKey(SpecKeys key) 
+{
+  std::string ctrl = "";
+  size_t l = 0;
+  int16_t addr = 0;
+  std::vector<byte> bytes;
+  int base = 10;
+
+  switch (key)
+  {
+  case JOYK_FIRE:
+  case SPECKEY_ENTER:
+    if (s_addr.length()<3 || s_data.length()==0){
+      playErrorBeep();
+      return;
+    }
+    addr = get_num(s_addr, 10);
+    base = (s_addr[1]=='x') ? 16 : 10;
+    bytes = get_bytes(s_data, base);
+    for (int i=0; i<bytes.size(); i++){
+      machine->z80_poke(addr+i, bytes[i]);
+    }
+    updateDisplay();
+    break;
+  case SPECKEY_H:
+  {
+    m_navigationStack->push(new MessageScreen("HELP", {
+      "Enter the address and the data to be poked.",
+      "If Addr starts with 0x values are hex, else decimal.",
+      "Data is space separated.",
+      "",
+      "T - switch btween Addr and Data",
+      "Z/Delete - Delete character",
+      "Enter - poke data",
+      "Q/Break - Quit",
+      }, m_tft, m_hdmiDisplay, m_audioOutput));
+    break;
+  }
+  case SPECKEY_Z:
+  case SPECKEY_DEL:
+    ctrl = getControlString();
+    l = ctrl.length();
+    if (l == 0){
+      playErrorBeep();
+      return;
+    }
+    ctrl.pop_back();
+    setControlString(ctrl);
+    updateDisplay();
+    break;
+  case SPECKEY_T:
+    active_control = 1 - active_control;
+    updateDisplay();
+    break;
+  case SPECKEY_Q:
+  case SPECKEY_BREAK:
+    m_navigationStack->pop();
+    return;
+  default:
+    if (specKeyToLetter.find(key) == specKeyToLetter.end() && key != SPECKEY_SPACE)
+      break;
+    char chr = (key==SPECKEY_SPACE) ? ' ' : specKeyToLetter.at(key);
+    if (chr == 'X'){
+      bool bad = false;
+      if (active_control == 1){
+        // Only needs to be used for address. Bytes will be the same base
+        bad = true;
+      } else if (s_addr.length()!=1 || s_addr[0] != '0'){
+        // Can only use after a 0 in the first position
+        bad = true;
+      }
+      if (bad){
+        playErrorBeep();
+        return;
+      }
+      // Convert to lowercase
+      s_addr.push_back('x');
+      updateDisplay();
+      return;
+    }
+    if (chr == ' '){
+      // Can only be used to separate data
+      if (active_control == 0){
+        playErrorBeep();
+        return;
+      }
+      s_data.push_back(chr);
+      updateDisplay();
+      return;
+    }
+    if (isHexadecimalDigit(chr)) {
+      ctrl = getControlString();
+      ctrl.push_back(chr);
+      setControlString(ctrl);
+      playKeyClick();
+      updateDisplay();
+      return;
+    }
+  }
+};
+
+void PokeScreen::updateDisplay()
+{
+  m_tft.loadFont(GillSans_15_vlw);
+  m_tft.startWrite();
+  m_tft.fillRect(0, 0, m_tft.width(), m_tft.height(), TFT_BLACK);
+  m_tft.drawRect(0, 0, m_tft.width(), m_tft.height(), TFT_WHITE);
+  m_tft.setTextColor(TFT_CYAN, TFT_BLACK);
+  m_tft.drawString("Poke Screen (H for help)", 2, 2);
+
+  m_tft.setTextColor(TFT_WHITE, TFT_BLACK);
+  const char* c_addr = "Addr:";
+  auto textSize = m_tft.measureString(c_addr);
+  const int16_t edit_y = textSize.x + 7;
+  int16_t cursor_x;
+
+  m_tft.drawString(c_addr, 2, 20);
+  cursor_x = m_tft.drawStringAndMeasure(s_addr.c_str(), edit_y, 20);
+  if (active_control == 0){
+    m_tft.fillRect(cursor_x, 20, 2, textSize.y, CURSOR_COLOR);
+  }
+
+  m_tft.drawString("Data:", 2, 40);
+  cursor_x = m_tft.drawStringAndMeasure(s_data.c_str(), edit_y, 40);
+  if (active_control == 1){
+    m_tft.fillRect(cursor_x, 40, 2, textSize.y, CURSOR_COLOR);
+  }
+
+  uint16_t addr;
+  if (s_addr.length()<3)
+    addr = 0;
+  else
+    addr = get_num(s_addr, 10);
+
+  char buf[16];
+  bool is_hex = s_addr[1] == 'x';
+  std::vector<byte> pokes;
+  if (s_data.length()){
+    // Base doesn't really matter here - doing this just to count the bytes
+    pokes = get_bytes(s_data, 16);
+  }
+
+  uint16_t poke_len = pokes.size();
+  if (poke_len == 0){
+    poke_len = 1;
+  }
+  uint16_t start_addr = addr - 4;
+  uint16_t end_addr = addr + poke_len + 4;
+
+  m_tft.setTextColor(TFT_YELLOW, TFT_BLACK);
+  cursor_x = m_tft.drawStringAndMeasure("Bytes at ", 2, 60);
+  if (is_hex)
+    sprintf(buf, "%04X", addr);
+  else
+    sprintf(buf, "%d", addr);
+  cursor_x = m_tft.drawStringAndMeasure(buf, cursor_x, 60);
+  cursor_x = 2;
+
+  for (int i=start_addr; i<end_addr; i++){
+    auto b = machine->z80_peek(i);
+    if (is_hex)
+      sprintf(buf, "%02X", b);
+    else
+      sprintf(buf, "%d", b);
+    if (i<addr || i>=addr+poke_len)
+      m_tft.setTextColor(TFT_WHITE, TFT_BLACK);
+    else
+      m_tft.setTextColor(TFT_YELLOW, TFT_BLACK);
+    cursor_x = m_tft.drawStringAndMeasure(buf, cursor_x, 80) + 5;
+  }
+
+  m_tft.endWrite();
+}
+
+std::vector<std::string> PokeScreen::split(const std::string &s, char delim){
+  std::vector<std::string> result;
+  std::stringstream ss(s);
+  std::string item;
+
+  while (getline(ss, item, delim)){
+    result.push_back(item);
+  }
+  return result;
+}
+
+// Parse a string as a number with the specified base.
+// If the string starts with 0x the base is ignored and the 
+// string is parsed as hex
+int16_t PokeScreen::get_num(const std::string &s, int base){
+  if (s[0] == '0' && s[1] == 'x'){
+    base = 16;
+  }
+  return std::stoi(s, nullptr, base);
+}
+
+// Parse a string of bytes delimited by single spaces
+std::vector<byte> PokeScreen::get_bytes(const std::string &s, int base){
+  std::vector<byte> result;
+  auto s_bytes = split(s, ' ');
+
+  for (const std::string& s_byte: s_bytes){
+    if (s_byte.length()==0)
+      continue;
+    auto b = get_num(s_byte, base) & 0xFF;
+    result.push_back(b);
+  }
+  return result;
+}
+
+std::string PokeScreen::getControlString(){
+  switch(active_control){
+    case 0:
+      return s_addr;
+    default:
+      return s_data;
+  }
+}
+
+void PokeScreen::setControlString(std::string str){
+  switch(active_control){
+    case 0:
+      s_addr = str;
+      break;
+    default:
+      s_data = str;
+      break;
+  }
+}

--- a/firmware/src/Screens/PokeScreen.h
+++ b/firmware/src/Screens/PokeScreen.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "MessageScreen.h"
+#include "NavigationStack.h"
+#include "Screen.h"
+#include "../TFT/TFTDisplay.h"
+#include "fonts/GillSans_25_vlw.h"
+#include "fonts/GillSans_15_vlw.h"
+#include "../Emulator/spectrum.h"
+#include "../Emulator/snaps.h"
+
+
+class IFiles;
+
+class PokeScreen : public Screen
+{
+private:
+  ZXSpectrum *machine = nullptr;
+  std::string s_addr = "0x5800";
+  std::string s_data = "";
+  byte active_control = 0;
+public:
+  PokeScreen(
+      Display &tft,
+      HDMIDisplay *hdmiDisplay,
+      AudioOutput *audioOutput,
+      ZXSpectrum *machine) : machine(machine), Screen(tft, hdmiDisplay, audioOutput, nullptr)
+  {
+  }
+
+  void didAppear()
+  {
+    updateDisplay();
+  }
+
+  void pressKey(SpecKeys key);
+  void updateDisplay();
+
+private:
+  std::vector<std::string> split(const std::string &s, char delim);
+  
+  // Parse a string as a number with the specified base (10 if not specified).
+  // If the string starts with 0x the base is ignored and the 
+  // string is parsed as hex
+  int16_t get_num(const std::string &s, int base);
+
+  // Parse a string of bytes delimited by single spaces
+  std::vector<byte> get_bytes(const std::string &s, int base);
+
+  std::string getControlString();
+  void setControlString(std::string str);
+};

--- a/firmware/src/TFT/Display.h
+++ b/firmware/src/TFT/Display.h
@@ -89,6 +89,18 @@ public:
     // not implemented here - maybe somewhere else?
   }
   virtual void drawPixel(uint16_t color, int x, int y);
+  // Draw a centered string at y
+  void drawCenterString(const char *string, int16_t y){
+    Point menuSize = measureString(string);
+    int centerX = (_width - menuSize.x) / 2;
+    drawString(string, centerX, y);
+  }
+  // Draw a string and return the rightmost x
+  int16_t drawStringAndMeasure(const char *string, int16_t x, int16_t y){
+    Point size = measureString(string);
+    drawString(string, x, y);
+    return x + size.x;
+  }
 protected:
   int _width;
   int _height;

--- a/firmware/src/TFT/TFTDisplay.h
+++ b/firmware/src/TFT/TFTDisplay.h
@@ -16,10 +16,14 @@
 #define ST7789_CMD_RASET 0x2B
 #define ST7789_CMD_RAMWR 0x2C
 
-#define TFT_WHITE 0xFFFF
-#define TFT_BLACK 0x0000
-#define TFT_RED 0xF800
-#define TFT_GREEN 0x07E0
+#define TFT_WHITE   0xFFFF
+#define TFT_BLACK   0x0000
+#define TFT_RED     0xF800
+#define TFT_GREEN   0x07E0
+#define TFT_BLUE    0x001F
+#define TFT_CYAN    0x07FF
+#define TFT_YELLOW  0xFFE0
+#define TFT_MAGENTA 0xF81F
 
 #define TFT_NOP     0x00
 #define TFT_SWRST   0x01


### PR DESCRIPTION
Added a poke screen accessible by pressing 'P' in the emulator menu (same area with time travel and snapshot saving). Address and bytes can be entered in hex or decimal. 

Pressing 'H' will open a small help screen for which a separate MessageScreen was added.

Smaller changes include extra color definitions and some helper functions for string drawing.