### PR TITLE
Optimization for ZX to LCD pixel rendering

### DIFF
--- a/firmware/src/Screens/EmulatorScreen/Renderer.cpp
+++ b/firmware/src/Screens/EmulatorScreen/Renderer.cpp
@@ -147,8 +147,8 @@ void Renderer::drawSpectrumScreen() {
       uint16_t tftPaperColor = specpal565[paperColor];
       const uint32_t u32Lookup[4] = {
         tftPaperColor | (tftPaperColor << 16), // 00
-        tftInkColor | (tftPaperColor << 16), // 01
-        tftPaperColor | (tftInkColor << 16), // 10
+        tftPaperColor | (tftInkColor << 16), // 01
+        tftInkColor | (tftPaperColor << 16), // 10
         tftInkColor | (tftInkColor << 16) // 11
       };
       for (int y = 0; y < 8; y++)


### PR DESCRIPTION
This change improves the "pixel pipeline" speed of the ZX emulator by reducing the number of instructions needed to convert the ZX framebuffer into RGB565 LCD format. The changes include coalesced writes (2 x uint16_t into 1 uint32_t), removal of the X loop, removal of conditional tests and branches and the addition of a 4-entry lookup table.
