### PR TITLE
Dezog debugger #35

### DIFF
--- a/firmware/src/AudioOutput/BuzzerOutput.h
+++ b/firmware/src/AudioOutput/BuzzerOutput.h
@@ -30,7 +30,7 @@ public:
   {
     // set up the ADC
     adc1_config_width(ADC_WIDTH_BIT_12);
-    adc1_config_channel_atten(ADC1_CHANNEL_4, ADC_ATTEN_DB_11);
+    adc1_config_channel_atten(ADC1_CHANNEL_4, ADC_ATTEN_DB_12);
     mBuzzerPin = buzzerPin;
     mBufferSemaphore = xSemaphoreCreateBinary();
     xSemaphoreGive(mBufferSemaphore);

--- a/firmware/src/Config.h
+++ b/firmware/src/Config.h
@@ -1,6 +1,11 @@
 #pragma once
 
+class EmulatorScreen;
 class IFiles;
+class Machine;
+class NavigationStack;
+class PacketHandler;
+class ZXSpectrum;
 
 // Create the Config class as a singleton, globally available from the entire application
 class Config 
@@ -15,6 +20,24 @@ public:
         return instance;
     }
 
+    // Screen stack
+    NavigationStack *navigationStack = nullptr;
+
+    // Serial packets handler
+    PacketHandler *packetHandler = nullptr;
+
+    // The emulator screen
+    EmulatorScreen *emulatorScreen = nullptr;
+    // The emulation machine wrapper
+    Machine *machine = nullptr;
+    // The Z80 emulation machine
+    ZXSpectrum *speccy = nullptr;
+
     // SDCard files
     IFiles *sdfiles = nullptr;
+
+    // Is serial used for debugging (or file transfer)
+    // True when DeZog debugger is connected and messages go to the emulator
+    // False when disconnected and messages are used for file transfers
+    bool m_serialDebugging = false;
 };

--- a/firmware/src/Config.h
+++ b/firmware/src/Config.h
@@ -1,0 +1,20 @@
+#pragma once
+
+class IFiles;
+
+// Create the Config class as a singleton, globally available from the entire application
+class Config 
+{
+private:
+    Config() = default;
+    ~Config() = default;
+
+public:
+    static Config& getConfig() {
+        static Config instance;
+        return instance;
+    }
+
+    // SDCard files
+    IFiles *sdfiles = nullptr;
+};

--- a/firmware/src/Debugger/DebuggerData.cpp
+++ b/firmware/src/Debugger/DebuggerData.cpp
@@ -1,0 +1,77 @@
+#include "../Config.h"
+#include "../FileLog.h"
+#include "../Screens/EmulatorScreen/Machine.h"
+#include "DebuggerData.h"
+
+/**
+ * Breakpoint that will last only until the next interrupt
+ */
+void DebuggerData::setTempBreakpoint(uint no, uint16_t addr)
+{
+    FileLog fl;
+    if (no > 1){
+        return;
+    }
+    temp_bkp[no].address = addr;
+    // Save the byte at address
+    temp_bkp[no].saved_byte = Config::getConfig().speccy->z80_peek(addr);
+    // Put RST instead
+    Config::getConfig().speccy->z80_poke(addr, BKP_INST);
+    fl.log("setTmpBkp %d: %04X %02X %02x", no, addr, temp_bkp[no].saved_byte,
+        Config::getConfig().speccy->z80_peek(addr));
+}
+
+uint8_t DebuggerData::addBreakpoint(uint16_t addr){
+    FileLog fl;
+    char vrt[10] = "--VIRT";
+    ZXSpectrum *speccy = Config::getConfig().speccy;
+    Breakpoint *bkp = new Breakpoint();
+    bkp->address = addr;
+    bkp->saved_byte = speccy->z80_peek(addr);
+    breakpoints[addr] = bkp;
+    // Check if this breakpoint would be at the current address
+    // In that case make it a virtual breakpoint
+    if (addr == speccy->z80Regs->PC.W){
+        speccy->z80Regs->virtual_breakpoint = addr;
+        vrt[0] = '+';
+    } else {
+        // Normal breakpoint - just change the instruction
+        speccy->z80_poke(addr, BKP_INST);
+        vrt[0] = 0;
+    }
+    fl.log("addBkp %04X %02X %02x %s", addr, bkp->saved_byte,
+        Config::getConfig().speccy->z80_peek(addr), vrt);
+    return bkp->saved_byte;
+}
+
+/**
+ * Return true if one of the breakpoints is hit
+ */
+bool DebuggerData::breakpointHit(uint16_t addr)
+{
+    if (breakpoints.contains(addr)){
+        return true;
+    }
+    if (temp_bkp[0].address == addr || temp_bkp[1].address == addr){
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Clean all temporary breakpoints
+ */
+void DebuggerData::clearTempBreakpoints()
+{
+    FileLog fl;
+    restoreMem(temp_bkp[0]);
+    temp_bkp[0].address = 0;
+    restoreMem(temp_bkp[1]);
+    temp_bkp[1].address = 0;
+    fl.log("Clr tmp bkp");
+}
+
+void DebuggerData::restoreMem(Breakpoint bkp)
+{
+    Config::getConfig().speccy->z80_poke(bkp.address, bkp.saved_byte);
+}

--- a/firmware/src/Debugger/DebuggerData.h
+++ b/firmware/src/Debugger/DebuggerData.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <map>
+typedef unsigned short uint16_t;
+
+// Pause reasons
+#define PAUSE_NO_REASON         0
+#define PAUSE_MANUAL            1
+#define PAUSE_BREAKPOINT_HIT    2
+#define PAUSE_WATCHPOINT_READ   3
+#define PAUSE_WATCHPOINT_WRITE  4
+// Just used as not set value
+#define PAUSE_NOT_SET           200
+#define PAUSE_OTHER             255
+
+// The instruction used for breakpoints (RST 08)
+#define BKP_INST                0xCF
+
+template<typename T>
+class AddrMap : public std::map<uint16_t, T>
+{
+public:
+    bool contains(uint16_t addr) {
+        try {
+            if (this->at(addr)){
+                return true;
+            } else {
+                return false;
+            }
+        } catch (const std::out_of_range& ex){
+            return false;
+        }
+    }
+};
+
+class Breakpoint
+{
+public:
+    uint16_t address;
+    uint8_t saved_byte;
+};
+
+class DebuggerData 
+{
+protected:
+    AddrMap<Breakpoint*> breakpoints;
+    Breakpoint temp_bkp[2];
+
+public:
+    DebuggerData() = default;
+    ~DebuggerData() = default;
+
+    void setTempBreakpoint(uint no, uint16_t addr);
+    void clearTempBreakpoints();
+    uint8_t addBreakpoint(uint16_t addr);
+    void removeBreakpoint(uint16_t addr);
+    bool breakpointHit(uint16_t addr);
+    void restoreMem(Breakpoint bkp);
+};

--- a/firmware/src/Emulator/spectrum.cpp
+++ b/firmware/src/Emulator/spectrum.cpp
@@ -83,6 +83,12 @@ int ZXSpectrum::runForFrame(AudioOutput *audioOutput, FILE *audioFile)
     // run for 224 cycles
     c += 224;
     uint16_t speakerValue = runForCycles(224);
+    if (z80Regs->debugging){
+      if (z80Regs->bkp_stop){
+        // TODO return or break here?
+        return c;
+      }
+    }
     borderColors[i] = hwopt.BorderColor & 0b00000111;
     audioBuffer[i] = speakerValue/4;
   }

--- a/firmware/src/Emulator/spectrum.h
+++ b/firmware/src/Emulator/spectrum.h
@@ -7,6 +7,7 @@
 #include "keyboard_defs.h"
 #include <string.h>
 #include "../AYSound/AySound.h"
+#include "../log.h"
 
 extern uint8_t speckey[8];
 
@@ -82,14 +83,14 @@ class Memory {
       for (int i = 0; i < 2; i++) {
         rom[i] = new MemoryPage();
         if (rom[i] == nullptr || rom[i]->data == nullptr) {
-          printf("Failed to allocate ROM");
+          LOG_E("Failed to allocate ROM");
         }
       }
       // allocate space for the memory banks
       for (int i = 0; i < 8; i++) {
         banks[i] = new MemoryPage();
         if (banks[i] == nullptr || banks[i]->data == nullptr) {
-          printf("Failed to allocate RAM");
+          LOG_E("Failed to allocate RAM");
         }
       }
       // wire up the default memory configuration - this will work for the 48k model and is the default for the 128k model
@@ -129,10 +130,10 @@ class Memory {
       }
     }
     void loadRom(const uint8_t *rom_data, int rom_len) {
-      printf("Loading ROM %d\n", rom_len);
+      LOG_I("Loading ROM %d\n", rom_len);
       int romCount = rom_len / 0x4000;
       for (int i = 0; i < romCount; i++) {
-        printf("Copying ROM %d\n", i);
+        LOG_I("Copying ROM %d\n", i);
         memcpy(rom[i]->data, rom_data + (i * 0x4000), 0x4000);
       }
     }

--- a/firmware/src/Emulator/z80/opcodes.h
+++ b/firmware/src/Emulator/z80/opcodes.h
@@ -1506,8 +1506,13 @@ RST (0x00);
 AddCycles (11);
 break;
 case RST_08:
-RST (0x08);
-AddCycles (11);
+if (regs->debugging){
+  regs->bkp_stop = true;
+  regs->PC.W--;
+} else {
+  RST (0x08);
+  AddCycles (11);
+}
 break;
 case RST_10:
 RST (0x10);

--- a/firmware/src/Emulator/z80/opddfdcb.h
+++ b/firmware/src/Emulator/z80/opddfdcb.h
@@ -261,15 +261,15 @@ switch (opcode)
   default:
     AddCycles (15);
 //    exit(1);
-    if (regs->DecodingErrors)
-      {
-	printf ("z80 core: Unknown instruction: ");
-	if (regs->we_are_on_ddfd == WE_ARE_ON_DD)
-	  printf ("DD");
-	else
-	  printf ("FD");
-	printf ("CB %02Xh %02Xh at PC=%04Xh.\n",
-		Z80ReadMem(r_PC - 2), Z80ReadMem(r_PC - 1), r_PC - 4);
-      }
+//    if (regs->DecodingErrors)
+//      {
+//	printf ("z80 core: Unknown instruction: ");
+//	if (regs->we_are_on_ddfd == WE_ARE_ON_DD)
+//	  printf ("DD");
+//	else
+//	  printf ("FD");
+//	printf ("CB %02Xh %02Xh at PC=%04Xh.\n",
+//		Z80ReadMem(r_PC - 2), Z80ReadMem(r_PC - 1), r_PC - 4);
+//      }
     break;
   }

--- a/firmware/src/Emulator/z80/z80.cpp
+++ b/firmware/src/Emulator/z80/z80.cpp
@@ -20,6 +20,9 @@
 #include "../spectrum.h"
 #include "tables.h"
 #include "z80.h"
+#include "../../Config.h"
+#include "../../FileLog.h"
+#include "../../Debugger/DebuggerData.h"
 
 #define Z80ReadMem(where) (mappedMemory[(where) >> 14]->data[(where) & 0x3FFF])
 #define Z80WriteMem(where, A, regs) ({              \
@@ -84,6 +87,8 @@ void Z80Reset(Z80Regs *regs)
   regs->IRequest = INT_NOINT;
   regs->we_are_on_ddfd = regs->dobreak = 0;
   regs->cycles = 0;
+  regs->bkp_stop = false;
+  regs->debugging = false;
 }
 
 /*====================================================================
@@ -140,6 +145,16 @@ uint16_t Z80Run(Z80Regs *regs, int numcycles)
       r_PC--;
       AddCycles(4);
     }
+    // Check if we have a virtual breakpoint
+    if (regs->virtual_breakpoint){
+      // Don't set if we're at the same address
+      if (regs->PC.W != regs->virtual_breakpoint){
+        // Set the breakpoint
+        Z80WriteMem(regs->virtual_breakpoint, BKP_INST, regs);
+        // Reset the value
+        regs->virtual_breakpoint = 0;
+      }
+    }
     /* read the opcode from memory (pointed by PC) */
     opcode = Z80ReadMem(regs->PC.W);
     regs->PC.W++;
@@ -183,6 +198,9 @@ uint16_t Z80Run(Z80Regs *regs, int numcycles)
     // printf("ROM loading routine hit\n");
     } else {
       spectrum->romLoadingRoutineHit = false;
+    }
+    if (regs->bkp_stop){
+      break;
     }
   }
   return micValue;

--- a/firmware/src/Emulator/z80/z80.h
+++ b/firmware/src/Emulator/z80/z80.h
@@ -129,6 +129,18 @@ typedef struct {
   int we_are_on_ddfd;
   /* the following is to take care of cycle counting */ 
   int cycles;
+  /* Stop from breakpoint */
+  bool bkp_stop;
+  /* True if we are connected to the debugger */
+  bool debugging;
+  /** 
+   * This will be set if there is a breakpoint at the current PC address.
+   * Since having a breakpoint at the current address will mean 
+   * stopping immediately, we're just making it a virtual breakpoint until
+   * we're clear of this address
+   * 0 = nothing set
+   */
+  uint16_t virtual_breakpoint = 0;
   /* DecodingErrors = set this to 1 for debugging purposes in order
    *    to trap undocumented or non implemented opcodes.
    *    Trace          = set this to 1 to start tracing. It's also set

--- a/firmware/src/FileLog.cpp
+++ b/firmware/src/FileLog.cpp
@@ -1,0 +1,58 @@
+#include <cstdarg>
+#include "FileLog.h"
+
+void FileLog::log(const char *format, ...)
+{
+    if (!active) return;
+
+    FILE *f = files->open(filename, "at");
+    char buf[LOG_BUF_SIZE];
+    int len = snprintf(buf, LOG_BUF_SIZE, "\n%d: ", millis());
+    fwrite(buf, 1, len, f);
+
+    va_list args;
+    va_start(args, format);
+    len = vsnprintf(buf, LOG_BUF_SIZE, format, args);
+    va_end(args);
+
+    fwrite(buf, 1, len, f);
+    buf[0] = '\n';
+    fwrite(buf, 1, 1, f);
+    fclose(f);
+}
+
+void FileLog::logbytes(const char *start, const char *end, uint8_t *data, int data_length)
+{
+    if (!active) return;
+
+    char buf[8];
+    const char sep[2] = {',', ' '};
+
+    if (data_length > MAX_BYTE_LEN){
+        data_length = MAX_BYTE_LEN;
+    }
+
+    FILE *f = files->open(filename, "at");
+    if (start){
+        fwrite(start, 1, strlen(start), f);
+    }
+    for (int i=0; i<data_length; i++){
+        if (i > 0){
+            fwrite(sep, 1, sizeof(sep), f);
+        }
+        int len = snprintf(buf, sizeof(buf), "%02X", data[i]);
+        fwrite(buf, 1, len, f);
+    }
+    if (end){
+        fwrite(end, 1, strlen(end), f);
+    }
+    buf[0] = '\n';
+    fwrite(buf, 1, 1, f);
+    fclose(f);
+}
+
+void FileLog::clear()
+{
+    FILE *f = files->open(filename, "w");
+    fclose(f);
+}

--- a/firmware/src/FileLog.h
+++ b/firmware/src/FileLog.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Config.h"
+#include "Files/Files.h"
+
+#define LOG_BUF_SIZE 1024
+#define MAX_BYTE_LEN 16
+
+class FileLog 
+{
+private:
+    IFiles *files;
+    const char *filename = "z80.log";
+    const bool active = false;
+
+public:
+    FileLog()
+    {
+        files = Config::getConfig().sdfiles;
+    }
+
+    void log(const char *format, ...);
+    void logbytes(const char *start, const char *end, uint8_t *data, int data_length);
+    void clear();
+};

--- a/firmware/src/Screens/EmulatorScreen.cpp
+++ b/firmware/src/Screens/EmulatorScreen.cpp
@@ -65,6 +65,10 @@ EmulatorScreen::EmulatorScreen(Display &tft, HDMIDisplay *hdmiDisplay, AudioOutp
     LOG_I("ROM loading routine hit");
     triggerLoadTape(); });
   gameLoader = new GameLoader(machine, renderer, audioOutput);
+  // Save the machine objects for debugger easy access
+  Config& cfg = Config::getConfig();
+  cfg.machine = machine;
+  cfg.speccy = machine->getMachine();
 }
 
 void EmulatorScreen::run(std::string filename, models_enum model)

--- a/firmware/src/Screens/EmulatorScreen.cpp
+++ b/firmware/src/Screens/EmulatorScreen.cpp
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include "../log.h"
 #include "../TFT/TFTDisplay.h"
 #include "../Emulator/spectrum.h"
 #include "../Emulator/snaps.h"
@@ -61,7 +62,7 @@ EmulatorScreen::EmulatorScreen(Display &tft, HDMIDisplay *hdmiDisplay, AudioOutp
   renderer = new Renderer(tft, audioOutput, hdmiDisplay);
   machine = new Machine(renderer, audioOutput, [&]()
                         {
-    Serial.println("ROM loading routine hit");
+    LOG_I("ROM loading routine hit");
     triggerLoadTape(); });
   gameLoader = new GameLoader(machine, renderer, audioOutput);
 }

--- a/firmware/src/Screens/EmulatorScreen/Machine.cpp
+++ b/firmware/src/Screens/EmulatorScreen/Machine.cpp
@@ -1,6 +1,7 @@
 #include "./Machine.h"
 #include "./Renderer.h"
 #include "../../AudioOutput/AudioOutput.h"
+#include "../../FileLog.h"
 
 void runnerTask(void *pvParameter)
 {
@@ -9,6 +10,7 @@ void runnerTask(void *pvParameter)
 }
 
 void Machine::runEmulator() {
+  FileLog fl;
   unsigned long lastTime = millis();
   while (1)
   {
@@ -16,6 +18,17 @@ void Machine::runEmulator() {
     {
       cycleCount += machine->runForFrame(audioOutput, audioFile);
       renderer->triggerDraw(machine->mem.currentScreen->data, machine->borderColors);
+      if (debuggerConnected){
+        if (machine->z80Regs->bkp_stop){
+          machine->z80Regs->bkp_stop = false;
+          uint16_t pc = machine->z80Regs->PC.W;
+          isRunning = false;
+          pauseReason = PAUSE_NO_REASON;
+          // Clear the temp breakpoints
+          debuggerData.clearTempBreakpoints();
+          fl.log("BP hit at :%04X", pc);
+        }
+      }
       unsigned long currentTime = millis();
       unsigned long elapsed = currentTime - lastTime;
       if (elapsed > 1000)
@@ -35,6 +48,8 @@ void Machine::runEmulator() {
       {
         romLoadingRoutineHitCallback();
       }
+      // Allow other tasks to interrupt 
+      vTaskDelay(0);
     }
     else
     {
@@ -68,6 +83,9 @@ void Machine::start(FILE *audioFile) {
   LOG_I("Starting machine");
   this->audioFile = audioFile;
   isRunning = true;
+  if (debuggerConnected){
+    machine->z80Regs->debugging = true;
+  }
   xTaskCreatePinnedToCore(runnerTask, "z80Runner", 8192, this, 5, NULL, 0);
 }
 

--- a/firmware/src/Screens/EmulatorScreen/Machine.cpp
+++ b/firmware/src/Screens/EmulatorScreen/Machine.cpp
@@ -23,13 +23,13 @@ void Machine::runEmulator() {
         lastTime = currentTime;
         float cycles = cycleCount / (elapsed * 1000.0);
         float fps = renderer->getFrameCount() / (elapsed / 1000.0);
-        Serial.printf("Executed at %.3FMHz cycles, frame rate=%.2f\n", cycles, fps);
+        LOG_V("Executed at %.3FMHz cycles, frame rate=%.2f", cycles, fps);
         renderer->resetFrameCount();
         cycleCount = 0;
         // save the state of the machine for time travel
         timeTravel->record(machine);
-        Serial.printf("Free heap: %d\n", ESP.getFreeHeap());
-        Serial.printf("Free PSRAM: %d\n", ESP.getFreePsram());
+        LOG_I("Free heap: %d", ESP.getFreeHeap());
+        LOG_D("Free PSRAM: %d", ESP.getFreePsram());
       }
       if (machine->romLoadingRoutineHit)
       {
@@ -46,7 +46,7 @@ void Machine::runEmulator() {
 
 Machine::Machine(Renderer *renderer, AudioOutput *audioOutput, std::function<void()> romLoadingRoutineHitCallback)
 : renderer(renderer), audioOutput(audioOutput), romLoadingRoutineHitCallback(romLoadingRoutineHitCallback) {
-  Serial.println("Creating machine");
+  LOG_I("Creating machine");
   machine = new ZXSpectrum();
   timeTravel = new TimeTravel();
 }
@@ -58,14 +58,14 @@ void Machine::updateKey(SpecKeys key, uint8_t state) {
 }
 
 void Machine::setup(models_enum model) {
-  Serial.println("Setting up machine");
+  LOG_I("Setting up machine");
   machine->reset();
   machine->init_spectrum(model);
   machine->reset_spectrum(machine->z80Regs);
 }
 
 void Machine::start(FILE *audioFile) {
-  Serial.println("Starting machine");
+  LOG_I("Starting machine");
   this->audioFile = audioFile;
   isRunning = true;
   xTaskCreatePinnedToCore(runnerTask, "z80Runner", 8192, this, 5, NULL, 0);

--- a/firmware/src/Screens/EmulatorScreen/Machine.h
+++ b/firmware/src/Screens/EmulatorScreen/Machine.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <deque>
 #include "Renderer.h"
+#include "../../Debugger/DebuggerData.h"
 #include "../../Emulator/spectrum.h"
 #include "../../Serial.h"
 
@@ -147,8 +148,16 @@ class Machine {
   private:
     // the actual machine
     ZXSpectrum *machine = nullptr;
+  public:
     // are we currently running?
     bool isRunning = false;
+    // is the debugger connected
+    bool debuggerConnected = false;
+    // pause reason (manual break, breakpoint, ...)
+    uint8_t pauseReason = PAUSE_NOT_SET;
+    // data for debugging (breakpoints, watchpoints, other stuff)
+    DebuggerData debuggerData;
+  private:
     // the renderer - we trigger a redraw every frame
     Renderer *renderer = nullptr;
     // where are we sending audio?

--- a/firmware/src/Screens/EmulatorScreen/Machine.h
+++ b/firmware/src/Screens/EmulatorScreen/Machine.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "log.h"
 #include "stdio.h"
 #include <functional>
 #include <list>
@@ -57,12 +58,12 @@ public:
     for (int i = 0; i < 240; i++) {
       MemoryBank *memoryBank = new MemoryBank();
       if (!memoryBank) {
-        Serial.println("Could not allocate memory bank");
+        LOG_E("Could not allocate memory bank");
         return;
       }
       memoryBank->data = (uint8_t *) ps_malloc(0x4000);
       if (!memoryBank->data) {
-        Serial.println("Could not allocate memory bank data");
+        LOG_E("Could not allocate memory bank data");
         return;
       }
       memoryBanks.push_back(memoryBank);
@@ -81,7 +82,7 @@ public:
       }
     }
     ensureMemoryBanks(memoryBankCount);
-    Serial.printf("Saving %d memory banks\n", memoryBankCount);
+    LOG_D("Saving %d memory banks", memoryBankCount);
     // create a new time travel instant
     TimeTravelInstant *instant = new TimeTravelInstant();
     // copy the memory banks
@@ -112,7 +113,7 @@ public:
       }
       delete oldestInstant;
     }
-    Serial.printf("Recorded time travel instant %d\n", timeTravelInstants.size());
+    LOG_D("Recorded time travel instant %d", timeTravelInstants.size());
     return true;
   }
   // rewind the machine to a previous state
@@ -180,14 +181,14 @@ class Machine {
       // record the current state
       timeTravel->record(machine);
       timeTravelPosition = timeTravel->size() - 1;
-      Serial.printf("Starting time travel %d\n", timeTravelPosition);
+      LOG_D("Starting time travel %d", timeTravelPosition);
     }
     void stepBack() {
       if (timeTravelPosition > 0) {
         timeTravelPosition--;
         timeTravel->rewind(machine, timeTravelPosition);
         renderer->forceRedraw(machine->mem.currentScreen->data, machine->borderColors);
-        Serial.printf("Time travel %d\n", timeTravelPosition);
+        LOG_D("Time travel %d", timeTravelPosition);
       }
     }
     void stepForward() {
@@ -195,7 +196,7 @@ class Machine {
         timeTravelPosition++;
         timeTravel->rewind(machine, timeTravelPosition);
         renderer->forceRedraw(machine->mem.currentScreen->data, machine->borderColors);
-        Serial.printf("Time travel %d\n", timeTravelPosition);
+        LOG_D("Time travel %d", timeTravelPosition);
       }
     }
     void stopTimeTravel() {

--- a/firmware/src/Screens/EmulatorScreen/Renderer.h
+++ b/firmware/src/Screens/EmulatorScreen/Renderer.h
@@ -2,6 +2,7 @@
 #include <freertos/FreeRTOS.h>
 #include <string.h>
 #include "../../TFT/Display.h"
+#include "../../log.h"
 #include "../../Serial.h"
 
 void displayTask(void *pvParameters);
@@ -63,13 +64,13 @@ public:
       screenBuffer = (uint8_t *)malloc(6912);
       if (screenBuffer == NULL)
       {
-        Serial.println("Failed to allocate screen buffer");
+        LOG_E("Renderer", "Failed to allocate screen buffer");
       }
       memset(screenBuffer, 0, 6912);
       currentScreenBuffer = (uint8_t *)malloc(6912);
       if (currentScreenBuffer == NULL)
       {
-        Serial.println("Failed to allocate current screen buffer");
+        LOG_E("Renderer", "Failed to allocate current screen buffer");
       }
       memset(currentScreenBuffer, 0, 6912);
       m_displaySemaphore = xSemaphoreCreateBinary();

--- a/firmware/src/Screens/GameFilePickerScreen.h
+++ b/firmware/src/Screens/GameFilePickerScreen.h
@@ -3,6 +3,7 @@
 #include "PickerScreen.h"
 #include "../Files/Files.h"
 #include "EmulatorScreen.h"
+#include "../log.h"
 
 class GameFilePickerScreen : public PickerScreen<FileInfoPtr>
 {
@@ -22,7 +23,7 @@ class GameFilePickerScreen : public PickerScreen<FileInfoPtr>
         // if we found the emulator screen and if we're loading a tape file then we've been triggered due to the user starting the
         // load routine from the emulator screen. We just need to tell the emulator screen to load the tape file and pop back to it
         if (emulatorScreen != nullptr && (item->getExtension() == ".tap" || item->getExtension() == ".tzx")) {
-          Serial.println("Loading tape file into existing emulator screen");
+          LOG_I("Loading tape file into existing emulator screen");
           // pop to the emaulator screen - get a local copy of the stack as it will be set to null when we pop
           NavigationStack *navStack = m_navigationStack;
           while(navStack->stack.back() != emulatorScreen) {
@@ -31,7 +32,7 @@ class GameFilePickerScreen : public PickerScreen<FileInfoPtr>
           emulatorScreen->loadTape(item->getPath());
           return;
         }
-        Serial.println("Starting new emulator screen");
+        LOG_I("Starting new emulator screen");
         drawBusy();
         emulatorScreen = new EmulatorScreen(m_tft, m_hdmiDisplay, m_audioOutput, m_files);
         // TODO - we should pick the machine to run on - 48k or 128k

--- a/firmware/src/Screens/MainMenuScreen.h
+++ b/firmware/src/Screens/MainMenuScreen.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "log.h"
 #include "PickerScreen.h"
 #include "../Files/Files.h"
 #include "ErrorScreen.h"
@@ -9,6 +10,7 @@
 #include "GameFilePickerScreen.h"
 #include "AboutScreen.h"
 #include "TestScreen.h"
+#include "../FileLog.h"
 
 static const std::vector<std::string> gameValidExtensions = {".z80", ".sna", ".tap", ".tzx"};
 static const std::vector<std::string> videoValidExtensions = {".avi"};
@@ -45,6 +47,8 @@ public:
                                    { this->showGames(); }),
         std::make_shared<MenuItem>("Snapshots", [&]()
                                    { this->showSnapshots(); }),
+        std::make_shared<MenuItem>("Debugger", [&]()
+                                   { this->runDebugger(); }),
         std::make_shared<MenuItem>("Video Player", [&]()
                                    { this->showVideos(); }),
         std::make_shared<MenuItem>("About", [&]()
@@ -75,6 +79,26 @@ public:
     emulatorScreen->run("", models_enum::SPECMDL_128K);
     // touchKeyboard->setToggleMode(true);
     m_navigationStack->push(emulatorScreen);
+  }
+  void runDebugger()
+  {
+    // Clear the log
+    FileLog fl;
+    fl.clear();
+    // Turn debugging marker on
+    config.m_serialDebugging = true;
+
+    EmulatorScreen *emulatorScreen = new EmulatorScreen(m_tft, m_hdmiDisplay, m_audioOutput, m_files);
+    // For now will start as 48K. Later figure out what to do for the others
+    emulatorScreen->run("", models_enum::SPECMDL_48K);
+    m_navigationStack->push(emulatorScreen);
+
+    // Save the screen in config for easy access
+    config.emulatorScreen = emulatorScreen;
+
+    // Disable logging, so we can use the serial only for debugging
+    LOG_I("Entering debug mode - logging disabled");
+    master_log_level = ESP_LOG_NONE;
   }
 
   template <class FilterPickerScreen_T> void showAlphabetPicker(

--- a/firmware/src/Screens/Screen.h
+++ b/firmware/src/Screens/Screen.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "../Config.h"
 #include "Emulator/keyboard_defs.h"
 #include "AudioOutput/AudioOutput.h"
 #include "sounds/bell.h"
@@ -26,6 +27,8 @@ class Screen {
     HDMIDisplay *m_hdmiDisplay = nullptr;
     AudioOutput *m_audioOutput;
     IFiles *m_files;
+    // Configuration
+    Config& config = Config::getConfig();
   public:
   Screen(Display &tft, HDMIDisplay *hdmiDisplay, AudioOutput *audioOutput, IFiles *files) 
   : m_tft(tft), m_hdmiDisplay(hdmiDisplay), m_audioOutput(audioOutput), m_files(files) {}

--- a/firmware/src/SerialInterface/PacketHandler.cpp
+++ b/firmware/src/SerialInterface/PacketHandler.cpp
@@ -1,0 +1,550 @@
+#include "FileLog.h"
+#include "PacketHandler.h"
+#include "Emulator/spectrum.h"
+#include "Emulator/z80/z80.h"
+#include "Screens/EmulatorScreen.h"
+#include "Screens/EmulatorScreen/Machine.h"
+
+#define DEZOG_START_BYTE (uint8_t)0xA5
+
+#define CMD_INIT             1
+#define CMD_CLOSE            2
+#define CMD_GET_REGISTERS    3
+#define CMD_SET_REGISTER     4
+#define CMD_WRITE_BANK       5
+#define CMD_CONTINUE         6
+#define CMD_PAUSE            7
+#define CMD_READ_MEM         8
+#define CMD_WRITE_MEM        9
+#define CMD_SET_SLOT         10
+#define CMD_GET_TBBLUE_REG   11
+#define CMD_SET_BORDER       12
+#define CMD_SET_BREAKPOINTS  13
+#define CMD_RESTORE_MEM      14
+#define CMD_LOOPBACK         15
+// Commands 16 to 19 are sprites commands, unlikely to be implemented
+#define CMD_READ_PORT        20
+#define CMD_WRITE_PORT       21
+#define CMD_EXEC_ASM         22
+#define CMD_INT_ON_OFF       23
+#define CMD_CMD_ADD_BKPT     40
+#define CMD_CMD_REM_BKPT     41
+#define CMD_CMD_ADD_WATCH    42
+#define CMD_CMD_REM_WATCH    43
+#define CMD_READ_STATE       50
+#define CMD_WRITE_STATE      51
+
+// Notifications (only one for now)
+#define NTF_PAUSE            1
+
+#define MEM_PTR(emu, addr) ((emu)->mem.mappedMemory[(addr) >> 14]->data+((addr) & 0x3FFF))
+
+typedef struct {
+  uint16_t PC;
+  uint16_t SP;
+  uint16_t AF;
+  uint16_t BC;
+  uint16_t DE;
+  uint16_t HL;
+  uint16_t IX;
+  uint16_t IY;
+  uint16_t AF2;
+  uint16_t BC2;
+  uint16_t DE2;
+  uint16_t HL2;
+  uint8_t R;
+  uint8_t I;
+  uint8_t IM;
+  uint8_t reserved;
+  uint8_t n_slots;
+  uint8_t slots[10];
+} DeZogRegsStruct;
+
+typedef union 
+{
+  DeZogRegsStruct regs;
+  uint8_t bytes[sizeof(DeZogRegsStruct)];
+} DeZogRegsUnion;
+
+void PacketHandler::debuggerWrite(uint8_t byte)
+{
+  transport.write(byte);
+}
+
+void PacketHandler::debuggerWrite(uint8_t *data, uint16_t length)
+{
+  transport.write(data, length);
+}
+
+void PacketHandler::debuggerSendPacket(uint8_t seq_no, uint8_t *data, uint16_t data_length)
+{
+  FileLog fl;
+  // Length is data size plus the seqno byte
+  uint32_t length = data_length + 1;
+  uint8_t bytes[4];
+  bytes[0] = length & 0xFF;
+  bytes[1] = (length >> 8) & 0xFF;
+  bytes[2] = (length >> 16) & 0xFF;
+  bytes[3] = (length >> 24) & 0xFF;
+  debuggerWrite(DEZOG_START_BYTE);
+  debuggerWrite(bytes, 4);
+  debuggerWrite(seq_no);
+  if (data_length) {
+    debuggerWrite(data, data_length);
+  }
+  fl.log(" ->(%d) len:%x", seq_no, data_length);
+  fl.logbytes(" ->[", "]", data, data_length);
+}
+
+void PacketHandler::debuggerSendMessage(uint8_t *data, uint16_t data_length)
+{
+  debuggerSendPacket(m_debuggerSeqNo, data, data_length);
+}
+
+void PacketHandler::debuggerSendNotification(uint8_t *data, uint16_t data_length)
+{
+  debuggerSendPacket(0, data, data_length);
+}
+
+// cmd 1
+void PacketHandler::cmdInit()
+{
+  auto bl = BusyLight();
+  // Stop the emulator
+  config.machine->pause();
+  config.machine->debuggerConnected = true;
+  config.speccy->z80Regs->debugging = true;
+  // *** Reply ***
+  // Error
+  dataBuffer[0] = 0;
+  // Version 2.1.0
+  dataBuffer[1] = 2;
+  dataBuffer[2] = 1;
+  dataBuffer[3] = 0;
+  // Machine type 2 = 48K
+  dataBuffer[4] = 2;
+  // Machine name (asciiz)
+  strcpy((char*)dataBuffer+5, HARDWARE_VERSION_STRING);
+  int len = strlen((char*)dataBuffer+5) + 6;
+  debuggerSendMessage(dataBuffer, len);
+}
+
+// cmd 2
+void PacketHandler::cmdClose()
+{
+  // Nothing to do here. Just blink the light
+  auto bl = BusyLight();
+  config.machine->debuggerConnected = false;
+  config.machine->resume();
+
+  debuggerSendMessage(dataBuffer, 0);
+}
+
+// cmd 3
+/**
+ * Register order (offsets are for dataBuffer, not for reply)
+ * PC, SP, AF, BC
+ * DE, HL, IX, IY
+ * AF2, BC2, DE2, HL2
+ * +24 R
+ * +25 I
+ * +26 IM
+ * +27 - reserved
+ * +28 - Number of slots that follw
+ * +29 - Slot[n] - bank number
+ */
+void PacketHandler::cmdGetRegisters()
+{
+  DeZogRegsUnion regs;
+  Z80Regs *emu_regs = config.speccy->z80Regs;
+
+  regs.regs.PC = emu_regs->PC.W;
+  regs.regs.SP = emu_regs->SP.W;
+  regs.regs.AF = emu_regs->AF.W;
+  regs.regs.BC = emu_regs->BC.W;
+  regs.regs.DE = emu_regs->DE.W;
+  regs.regs.HL = emu_regs->HL.W;
+  regs.regs.IX = emu_regs->IX.W;
+  regs.regs.IY = emu_regs->IY.W;
+  regs.regs.AF2 = emu_regs->AFs.W;
+  regs.regs.BC2 = emu_regs->BCs.W;
+  regs.regs.DE2 = emu_regs->DEs.W;
+  regs.regs.HL2 = emu_regs->HLs.W;
+  regs.regs.R = emu_regs->R.W;
+  regs.regs.I = emu_regs->I;
+  regs.regs.IM = emu_regs->IM;
+  regs.regs.n_slots = 0;
+
+  debuggerSendMessage(regs.bytes, sizeof(DeZogRegsStruct));
+}
+
+// cmd 4
+void PacketHandler::cmdSetRegister()
+{
+  uint8_t reg_id = dataBuffer[0];
+  uint16_t val = dataBuffer[1] | dataBuffer[2] << 8;
+  ZXSpectrum *speccy = config.speccy;
+  Z80Regs *regs = speccy->z80Regs;
+  switch(reg_id){
+    case 0:
+      regs->PC.W = val;
+      break;
+    case 1:
+      regs->SP.W = val;
+      break;
+    case 2:
+      regs->AF.W = val;
+      break;
+    case 3:
+      regs->BC.W = val;
+      break;
+    case 4:
+      regs->DE.W = val;
+      break;
+    case 5:
+      regs->HL.W = val;
+      break;
+    case 6:
+      regs->IX.W = val;
+      break;
+    case 7:
+      regs->IY.W = val;
+      break;
+    case 8:
+      regs->AFs.W = val;
+      break;
+    case 9:
+      regs->BCs.W = val;
+      break;
+    case 10:
+      regs->DEs.W = val;
+      break;
+    case 11:
+      regs->HLs.W = val;
+      break;
+    case 13:
+      regs->IM = val;
+      break;
+    case 34:
+      regs->R.W = val;
+      break;
+    case 35:
+      regs->I = val;
+      break;
+  }
+  // *** Reply is empty ***
+  debuggerSendMessage(dataBuffer, 0);
+}
+
+// cmd 5
+/**
+ * Default banks (8K - 2000):
+ * A - 4000
+ * B - 6000
+ * 
+ * 4 - 8000
+ * 5 - A000
+ * 
+ * 0 - C000
+ * 1 - E000
+ */
+void PacketHandler::cmdWriteBank()
+{
+  auto bl = BusyLight();
+  ZXSpectrum *speccy = config.speccy;
+  if (speccy == nullptr){
+    // Should not get here. But if it gets, then the debugger will lose connection
+    return;
+  }
+  uint8_t bank = dataBuffer[0];
+  uint16_t addr = 0;
+  switch (bank){
+    case 0xA:
+      addr = 0x4000;
+      break;
+    case 0xB:
+      addr = 0x6000;
+      break;
+    case 0x4:
+      addr = 0x8000;
+      break;
+    case 0x5:
+      addr = 0xA000;
+      break;
+    case 0x0:
+      addr = 0xC000;
+      break;
+    case 0x1:
+      addr = 0xE000;
+      break;
+    default:
+      // Shouldn't get here for 48K
+      return;
+  };
+  memcpy(MEM_PTR(speccy, addr), dataBuffer + 1, 0x2000);
+
+  // *** Reply ***
+  // 0 = No error
+  dataBuffer[0] = 0;
+  // 1 = Error string zero terminated - empty
+  dataBuffer[1] = 0;
+  debuggerSendMessage(dataBuffer, 2);
+}
+
+// cmd 6
+void PacketHandler::cmdContinue()
+{
+  FileLog fl;
+  fl.log("cmdContinue");
+
+  // Check Bkp 1
+  if (dataBuffer[0] == 1){
+    // Enable bkp 1
+    uint16_t addr = dataBuffer[1] | dataBuffer[2] << 8;
+    config.machine->debuggerData.setTempBreakpoint(0, addr);
+  }
+  // Check Bkp 2
+  if (dataBuffer[3] == 1){
+    // Enable bkp 2
+    uint16_t addr = dataBuffer[4] | dataBuffer[5] << 8;
+    config.machine->debuggerData.setTempBreakpoint(1, addr);
+  }
+  // Not used for now
+  uint8_t alt_cmd = dataBuffer[6];
+  uint16_t step_over_start = dataBuffer[7] | dataBuffer[8] << 8;
+  uint16_t step_over_end = dataBuffer[9] | dataBuffer[10] << 8;
+
+  config.emulatorScreen->resume();
+
+  // *** Reply ***
+  debuggerSendMessage(dataBuffer, 0);
+}
+
+// cmd 7
+void PacketHandler::cmdPause()
+{
+  // TODO - consider pausing just the z80 machine
+  // (so that the renderer keeps showing the screen while debugging)
+  config.emulatorScreen->pause();
+  config.machine->pauseReason = PAUSE_MANUAL;
+
+  // *** Reply ***
+  debuggerSendMessage(dataBuffer, 0);
+}
+
+// cmd 8
+void PacketHandler::cmdReadMem()
+{
+  FileLog fl;
+  ZXSpectrum *speccy = config.speccy;
+  uint16_t addr = dataBuffer[1] | dataBuffer[2] << 8;
+  uint16_t len = dataBuffer[3] | dataBuffer[4] << 8;
+  uint16_t ofs = 0;
+  //fl.log("- ReadMem %X (len:%x)", addr, len);
+  while (len > 0){
+    // Get address of the next bank
+    uint16_t naddr = (addr + 0x4000) & 0xC000;
+    uint16_t tlen = naddr - addr;
+    if (len < tlen) {
+      tlen = len;
+    }
+    //fl.log("- chunk %X (len:%x)", addr, tlen);
+    memcpy(dataBuffer+ofs, MEM_PTR(speccy, addr), tlen);
+    len -= tlen;
+    addr += tlen;
+    ofs += tlen;
+  }
+  // By now len=0 and ofs=len
+  debuggerSendMessage(dataBuffer, ofs);
+}
+
+// cmd 9
+void PacketHandler::cmdWriteMem()
+{
+
+}
+
+// cmd 10
+void PacketHandler::cmdSetSlot()
+{
+
+  // *** Reply ***
+  // No error
+  dataBuffer[0] = 0;
+  debuggerSendMessage(dataBuffer, 1);
+}
+
+// cmd 12
+void PacketHandler::cmdSetBorder()
+{
+  ZXSpectrum *speccy = config.speccy;
+  uint8_t b = speccy->z80_in(0xFE);
+  b &= ~7;
+  b |= (dataBuffer[0] & 7);
+  speccy->z80_out(0xFE, b);
+  // *** Reply ***
+  debuggerSendMessage(dataBuffer, 0);
+}
+
+// cmd 13
+void PacketHandler::cmdSetBreakpoints()
+{
+  int bkp_no = messageLength / 3;
+  for (int i=0; i<bkp_no; i++){
+    uint16_t addr = dataBuffer[i*3] | dataBuffer[i*3+1] << 8;
+    // Get the bank, but ignore for now
+    uint8_t bank = dataBuffer[i*3+2];
+    // Set the breakpoint and also save the instructions in the buffer
+    dataBuffer[i] = config.machine->debuggerData.addBreakpoint(addr);
+  }
+
+  // *** Reply ***
+  // Data is already in the buffer
+  debuggerSendMessage(dataBuffer, bkp_no);
+}
+
+// cmd 14
+void PacketHandler::cmdRestoreMem()
+{
+  FileLog fl;
+  int bkp_no = messageLength / 4;
+  for (int i=0; i<bkp_no; i++){
+    uint16_t addr = dataBuffer[i*4] | dataBuffer[i*4+1] << 8;
+    // Get the bank, but ignore for now
+    uint8_t bank = dataBuffer[i*4+2];
+    // Get the original byte and patch back
+    uint8_t byte = dataBuffer[i*4+3];
+    fl.log("restore %02X at %04X (%02X)", byte, addr, config.speccy->z80_peek(addr));
+    config.speccy->z80_poke(addr, byte);
+  }
+
+  // *** Reply ***
+  debuggerSendMessage(dataBuffer, 0);
+}
+
+// cmd 23
+void PacketHandler::cmdIntOnOff()
+{
+  // TODO - make it do something :)
+  // *** Reply ***
+  debuggerSendMessage(dataBuffer, 0);
+}
+
+
+/**
+ * DeZog packets:
+ * 4 bytes - length (LE)
+ * 1 byte - sequence no
+ * 1 byte - cmd id
+ * n bytes - data (command dependent)
+ */
+void PacketHandler::loop_dezog()
+{
+  FileLog fl;
+
+  // TODO - check for incomplete frames (e.g. when disconnected)
+  while (transport.available()){
+    uint32_t length = 0;
+    uint8_t cmd_id = 0;
+    for (int i=0; i<4; i++){
+      uint8_t b = transport.read();
+      length |= b << (i*8);
+    }
+    m_debuggerSeqNo = transport.read();
+    messageLength = length;
+    cmd_id = transport.read();
+
+    fl.log("~%d (%d), len:0x%x", cmd_id, m_debuggerSeqNo, length);
+
+    uint32_t length_read = transport.read(dataBuffer, length);
+    fl.logbytes("  *[", "]", dataBuffer, length);
+
+    if (length_read != length) {
+      // Couldn't read everything, just ignore
+      // TODO - could this desynchronize things?
+      fl.log("Ignored");
+      continue;
+    }
+    switch (cmd_id){
+      case CMD_INIT:
+        cmdInit();
+        break;
+      case CMD_CLOSE:
+        cmdClose();
+        break;
+      case CMD_GET_REGISTERS:
+        cmdGetRegisters();
+        break;
+      case CMD_SET_REGISTER:
+        cmdSetRegister();
+        break;
+      case CMD_WRITE_BANK:
+        cmdWriteBank();
+        break;
+      case CMD_CONTINUE:
+        cmdContinue();
+        break;
+      case CMD_PAUSE:
+        cmdPause();
+        break;
+      case CMD_READ_MEM:
+        cmdReadMem();
+        break;
+      case CMD_SET_SLOT:
+        cmdSetSlot();
+        break;
+      case CMD_SET_BORDER:
+        cmdSetBorder();
+        break;
+      case CMD_SET_BREAKPOINTS:
+        cmdSetBreakpoints();
+        break;
+      case CMD_RESTORE_MEM:
+        cmdRestoreMem();
+        break;
+      case CMD_LOOPBACK:
+        debuggerSendMessage(dataBuffer, length);
+        break;
+      case CMD_INT_ON_OFF:
+        cmdIntOnOff();
+        break;
+      default:
+        // TODO - find a way to report a not implemented command
+        fl.log(" ** Cmd:%d not implemented", cmd_id);
+        break;
+    }
+    vTaskDelay(0);
+  }
+  /**
+   * If we're here there are no commands to read.
+#include "../FileLog.h"
+   * Check if we are stopped and need to send a pause reason
+   */
+  Machine *machine = config.machine;
+  if (machine && !machine->isRunning && machine->pauseReason != PAUSE_NOT_SET){
+    fl.log(" =>Ntf: %d", machine->pauseReason);
+    // Send DeZog pause notification
+    uint16_t pc = config.speccy->z80Regs->PC.W;
+
+    dataBuffer[0] = NTF_PAUSE;
+    /**
+     * Break reason:
+     *  0 = no reason (e.g. a step-over)
+     *  1 = manual break
+     *  2 = breakpoint hit
+     *  3 = watchpoint hit read access
+     *  4 = watchpoint hit write access
+     *  255 = some other reason: the reason string might have useful information for the user
+     */
+    dataBuffer[1] = machine->pauseReason;
+    // Bkp/Wp address
+    dataBuffer[2] = pc & 0xFF;
+    dataBuffer[3] = pc >> 8;
+    // Bank
+    dataBuffer[4] = 0;
+    strcpy((char*)dataBuffer+5, "PAUSE");
+    debuggerSendNotification(dataBuffer, 11);
+    // Reset pause reason
+    machine->pauseReason = PAUSE_NOT_SET;
+  }
+}

--- a/firmware/src/SerialInterface/PacketHandler.h
+++ b/firmware/src/SerialInterface/PacketHandler.h
@@ -2,8 +2,11 @@
 #include <Arduino.h>
 #include <stdint.h>
 #include <map>
+#include "Config.h"
+#include "FileLog.h"
 #include "Messages/Message.h"
 #include "Transport.h"
+#include "Files/Files.h"
 
 #define FRAME_BYTE 0x7E
 #define ESCAPE_BYTE 0x7D
@@ -32,7 +35,8 @@ private:
     EXPECTING_FRAME_BYTE
   };
 
-  static constexpr uint16_t PACKET_DATA_BUFFER_SIZE = 1024;
+  // Increased number to accomodate larger data for DeZog
+  static constexpr uint16_t PACKET_DATA_BUFFER_SIZE = 0xC000;
 
   State state = State::WAITING_FOR_START_BYTE;
 
@@ -50,7 +54,13 @@ private:
   // packet handlers by packet type
   std::map<MessageId, MessageReciever *> messageHandlers;
 
+  // Configuration
+  Config& config = Config::getConfig();
+
 public:
+  // The DeZog message sequence no
+  uint8_t m_debuggerSeqNo = 0;
+
   PacketHandler(Transport &transport)
       : transport(transport)
   {
@@ -160,8 +170,17 @@ public:
     // we've got the CRC - now we expect the frame byte
     return State::EXPECTING_FRAME_BYTE;
   }
-
+  
   void loop()
+  {
+    if (config.m_serialDebugging){
+      loop_dezog();
+    } else {
+      loop_hdlc();
+    }
+  }
+
+  void loop_hdlc()
   {
     while (transport.available())
     {
@@ -375,4 +394,28 @@ private:
    * The underlying transport layer
    */
   Transport &transport;
+
+  // Functions used for the DeZog debugger
+  void loop_dezog();
+  void debuggerSendPacket(uint8_t seq_no, uint8_t *data, uint16_t data_length);
+  void debuggerSendMessage(uint8_t *data, uint16_t length);
+  void debuggerSendNotification(uint8_t *data, uint16_t length);
+  void debuggerWrite(uint8_t byte);
+  void debuggerWrite(uint8_t *data, uint16_t length);
+  void cmdInit();
+  void cmdClose();
+  void cmdGetRegisters();
+  void cmdSetRegister();
+  void cmdWriteBank();
+  void cmdContinue();
+  void cmdPause();
+  void cmdReadMem();
+  void cmdWriteMem();
+  void cmdSetSlot();
+
+  void cmdSetBorder();
+  void cmdSetBreakpoints();
+  void cmdRestoreMem();
+
+  void cmdIntOnOff();
 };

--- a/firmware/src/SerialInterface/SerialTransport.h
+++ b/firmware/src/SerialInterface/SerialTransport.h
@@ -5,9 +5,9 @@ class SerialTransport : public Transport
 {
 public:
   SerialTransport() {
-    Serial.setTimeout(1);
-    Serial.setTxBufferSize(20000);
-    Serial.setRxBufferSize(20000);
+    Serial.setTimeout(250);
+    Serial.setTxBufferSize(60000);
+    Serial.setRxBufferSize(60000);
   }
 
   bool available() override {
@@ -17,8 +17,14 @@ public:
   int read() override {
     return Serial.read();
   }
+  int read(uint8_t *data, int length){
+    return Serial.read(data, length);
+  }
   void write(uint8_t data) override {
     Serial.write(data);
+  }
+  void write(uint8_t *data, uint16_t length) override {
+    Serial.write(data, length);
   }
   void flush() {
     Serial.flush();

--- a/firmware/src/SerialInterface/Transport.h
+++ b/firmware/src/SerialInterface/Transport.h
@@ -9,8 +9,12 @@ public:
   virtual bool available() = 0;
   // read a byte
   virtual int read() = 0;
+  // read multiple bytes
+  virtual int read(uint8_t *data, int length) = 0;
   // write a byte
   virtual void write(uint8_t data) = 0;
+  // write multiple bytes
+  virtual void write(uint8_t *data, uint16_t length) = 0;
   // flush
   virtual void flush() = 0;
 };

--- a/firmware/src/log.cpp
+++ b/firmware/src/log.cpp
@@ -1,0 +1,3 @@
+#include "log.h"
+
+unsigned int master_log_level;

--- a/firmware/src/log.h
+++ b/firmware/src/log.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "Serial.h"
+
+extern unsigned int master_log_level;
+
+#define LOG_E(format, ...) if (master_log_level >= ESP_LOG_ERROR)   Serial.printf("E:" format "\n" __VA_OPT__(,) __VA_ARGS__)
+#define LOG_W(format, ...) if (master_log_level >= ESP_LOG_WARN)    Serial.printf("W:" format "\n" __VA_OPT__(,) __VA_ARGS__)
+#define LOG_I(format, ...) if (master_log_level >= ESP_LOG_INFO)    Serial.printf("I:" format "\n" __VA_OPT__(,) __VA_ARGS__)
+#define LOG_D(format, ...) if (master_log_level >= ESP_LOG_DEBUG)   Serial.printf("D:" format "\n" __VA_OPT__(,) __VA_ARGS__)
+#define LOG_V(format, ...) if (master_log_level >= ESP_LOG_VERBOSE) Serial.printf("V:" format "\n" __VA_OPT__(,) __VA_ARGS__)

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -14,6 +14,7 @@
  */
 #include "Serial.h"
 #include <esp_err.h>
+#include <log.h>
 #include <map>
 #include <vector>
 #include <sstream>
@@ -67,22 +68,23 @@ void setup(void)
   digitalWrite(BOARD_POWERON, HIGH);
   #endif
   Serial.begin(115200);
+  master_log_level = ESP_LOG_VERBOSE;
   // for(int i = 0; i < 5; i++) {
   //   BusyLight bl;
   //   vTaskDelay(pdMS_TO_TICKS(1000));
   //   Serial.println("Booting...");
   // }
   // print out avialable ram
-  Serial.printf("Free heap: %d\n", ESP.getFreeHeap());
-  Serial.printf("Free PSRAM: %d\n", ESP.getFreePsram());
+  LOG_V("Free heap: %d\n", ESP.getFreeHeap());
+  LOG_V("Free PSRAM: %d\n", ESP.getFreePsram());
   #ifdef POWER_PIN
   pinMode(POWER_PIN, OUTPUT);
   digitalWrite(POWER_PIN, POWER_PIN_ON);
   vTaskDelay(100);
   #endif
-  Serial.println("Starting up");
+  LOG_I("Starting up");
   #ifdef TFT_MOSI
-  Serial.println("Starting up SPI");
+  LOG_I("Starting up SPI");
   // Initialize SPI
   spi_bus_config_t buscfg = {
       .mosi_io_num = TFT_MOSI,
@@ -100,7 +102,7 @@ void setup(void)
       .intr_flags = 0,
   };
   ESP_ERROR_CHECK(spi_bus_initialize(SPI2_HOST, &buscfg, SPI_DMA_CH_AUTO));
-  Serial.println("SPI initialized");
+  LOG_I("SPI initialized");
   #endif
   // Files
   SDCard *sdFileSystem = nullptr;
@@ -196,7 +198,7 @@ void setup(void)
   // create the directory structure
   if (!files->createDirectory("/snapshots"))
   {
-    Serial.println("Failed to create /snapshots directory");
+    LOG_E("Failed to create /snapshots directory");
   }
   MainMenuScreen menuPicker(*tft, hdmiDisplay, audioOutput, files);
   navigationStack->push(&menuPicker);
@@ -242,7 +244,7 @@ void setup(void)
     1
   );
 
-  Serial.println("Running on core: " + String(xPortGetCoreID()));
+  LOG_I("Running on core: %d", xPortGetCoreID());
   // use the boot pin to open the emulator menu
   pinMode(0, INPUT_PULLUP);
   // just keep running

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 #include <sstream>
 #include "SPI.h"
+#include "Config.h"
 #include "AudioOutput/I2SOutput.h"
 #include "AudioOutput/PDMOutput.h"
 #include "AudioOutput/DACOutput.h"
@@ -245,6 +246,13 @@ void setup(void)
   );
 
   LOG_I("Running on core: %d", xPortGetCoreID());
+
+  // Save important variables into config
+  Config& cfg = Config::getConfig();
+  cfg.sdfiles = (IFiles*)sdFiles;
+  cfg.navigationStack = navigationStack;
+  cfg.packetHandler = packetHandler;
+
   // use the boot pin to open the emulator menu
   pinMode(0, INPUT_PULLUP);
   // just keep running


### PR DESCRIPTION
Implemented serial protocol for communication with DeZog for 48K. Since serial is used, the regular serial logging is turned off by a setting when going through the new **Debugger** menu entry. 

Breakpoints are implemented which allows step into/over, run to cursor. 
Pause is implemented in code, but DeZog doesn't send it to zxnext, so for now it's not possible to pause when running unless the code reaches a breakpoints. I have added a new remote type in DeZog, but the code is not good for a pull request yet. An option would be to use the boot button menu and request a pause from there. This wouldn't require a modification for DeZog.
Watchpoints are not implemented and may be difficult to implement but I haven't looked too much into it.

For a debugging session DeZog should be configured to use the `zxnext`  remote type (see below for an example), the Debugger emulator should be started on the Rainbow, and the session can be started with F5. 

    "configurations": [
    {
        ...
        "remoteType": "zxnext",
        "zxnext":{
            "serial": "...",
            "visualMemory": true,
            "memoryModel": "ZX48K",
            "ulaScreen": "spectrum",
            "zxKeyboard": "spectrum",
        }
        ...
    }